### PR TITLE
Improve scoreboard layout

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
 # models.py
-from typing import Optional
+from typing import Optional, List
 from sqlmodel import SQLModel, Field
 from pydantic import BaseModel
 from datetime import datetime
@@ -30,3 +30,7 @@ class Result(BaseModel):
     track_condition: str
     correct_weight: str
     raw_message: str
+    runners: Optional[List[str]] = None
+
+    class Config:
+        extra = "allow"

--- a/routes.py
+++ b/routes.py
@@ -15,6 +15,7 @@ from database import engine
 from models import Club, Venue, Result, DayPass  # Ensure DayPass exists in models.py
 from fastapi.templating import Jinja2Templates
 from fastapi import Query
+import re
 
 router = APIRouter()
 templates = Jinja2Templates(directory="templates")
@@ -47,6 +48,49 @@ def login(credentials: dict):
         venues = session.exec(select(Venue).where(Venue.club_id == club.id)).all()
         return {"club_id": club.id, "venues": [v.name for v in venues]}
 
+# Parse raw FinishLynx strings into race number and runner info
+def parse_raw_message(raw: str):
+    race_no = None
+    runners = []
+    if not raw:
+        return race_no, runners
+    lines = raw.splitlines()
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if race_no is None:
+            m = re.search(r"Race\s+(\d+)", line)
+            if m:
+                race_no = m.group(1)
+                continue
+        if line.startswith("[") or line.lower().startswith("race"):
+            m = re.search(r"Race\s+(\d+)", line)
+            if m:
+                race_no = m.group(1)
+            continue
+        parts = re.split(r"\s{2,}", line)
+        if len(parts) < 3:
+            continue
+        time = ""
+        weight = ""
+        if re.match(r"\d+:\d+\.\d+", parts[-1]):
+            time = parts.pop()
+        if parts and re.match(r"-?\d+(?:\.\d+)?", parts[-1]):
+            weight = parts.pop()
+        if len(parts) < 3:
+            continue
+        horse_no = parts[1]
+        horse_name = parts[2]
+        jockey = " ".join(parts[3:]) if len(parts) > 3 else ""
+        entry = f"{horse_no} {horse_name} - {jockey}".strip()
+        if weight:
+            entry += f" {weight}"
+        if time:
+            entry += f" {time}"
+        runners.append(entry)
+    return race_no, runners
+
 # Record day pass
 def record_day_pass(venue_name: str, club_id: int):
     now = datetime.utcnow()
@@ -65,6 +109,11 @@ def record_day_pass(venue_name: str, club_id: int):
 @router.post("/submit/{club_id}")
 async def submit_result(club_id: int, result: Result):
     result_data = result.dict()
+    race_num, runners = parse_raw_message(result_data.get("raw_message", ""))
+    if race_num and "race" not in result_data:
+        result_data["race"] = race_num
+    if not result_data.get("runners") and runners:
+        result_data["runners"] = runners
     filename = f"results_club_{club_id}.json"
 
     if not os.path.exists(filename):
@@ -87,6 +136,9 @@ async def submit_result(club_id: int, result: Result):
                 await connection.send_json(result_data)
             except:
                 continue
+
+    # Also broadcast to connected scoreboard displays
+    await broadcast_scoreboard(club_id, result_data)
 
     return {"status": "ok"}
 
@@ -195,14 +247,16 @@ def add_venue(
 @router.post("/admin/delete_venue")
 async def delete_venue(request: Request):
     data = await request.json()
-    await broadcast_scoreboard(venue_id, data)
     venue_id = data.get("venue_id")
 
     with Session(engine) as session:
         venue = session.get(Venue, venue_id)
         if venue:
+            club_id = venue.club_id
             session.delete(venue)
             session.commit()
+            # Notify connected scoreboards to refresh venue list
+            await broadcast_scoreboard(club_id, {"action": "delete_venue", "venue_id": venue_id})
     return {"status": "ok"}
 
 @router.get("/admin/results/{club_id}", response_class=HTMLResponse)

--- a/templates/scoreboard_display.html
+++ b/templates/scoreboard_display.html
@@ -10,40 +10,55 @@
             color: #fff;
             padding: 30px;
         }
-        .venue {
-            font-size: 2em;
+        .horse-ids {
+            display: flex;
+            justify-content: space-between;
             margin-bottom: 20px;
         }
-        .messages {
-            font-size: 1.2em;
+        .horse {
+            position: relative;
+            width: 15%;
+            text-align: center;
+            font-size: 5em;
+            font-weight: bold;
+        }
+        .horse .position {
+            position: absolute;
+            bottom: 5px;
+            left: 5px;
+            font-size: 0.3em;
+            color: #ff0;
+        }
+        .divider {
+            border-top: 2px solid #fff;
+            margin: 20px 0;
+        }
+        .center-info {
+            text-align: center;
+            font-size: 2em;
             margin-bottom: 15px;
         }
+        .messages {
+            text-align: center;
+            font-size: 1.5em;
+            margin-bottom: 20px;
+        }
         .results {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 20px;
+            text-align: center;
+            font-size: 1.2em;
         }
-        .result-card {
-            background-color: #222;
-            padding: 15px 25px;
-            border-radius: 10px;
-            min-width: 150px;
-        }
-        .track {
-            margin-top: 30px;
-            font-size: 1.1em;
-            color: #aaa;
-        }
+        .result-line { margin: 3px 0; }
     </style>
 </head>
 <body>
-    <div class="venue" id="venue">Venue Name</div>
+    <div class="horse-ids" id="horse-ids"></div>
+    <div class="divider"></div>
+    <div class="center-info" id="venue-track">Venue - Track</div>
     <div class="messages">
-        <div id="message1">Message Line 1</div>
-        <div id="message2">Message Line 2</div>
+        <div id="message1"></div>
+        <div id="message2"></div>
     </div>
     <div class="results" id="results"></div>
-    <div class="track" id="track">Track Condition: Good 4 | Correct Weight: No</div>
 
     <script>
         function getClubIdFromURL() {
@@ -72,23 +87,35 @@
             console.log("Received data:", event.data);
             const data = JSON.parse(event.data);
 
-            document.getElementById("venue").textContent = data.venue_name || "Venue Name";
-            document.getElementById("message1").textContent = data.message1 || "";
-            document.getElementById("message2").textContent = data.message2 || "";
+            const horseEl = document.getElementById("horse-ids");
+            horseEl.innerHTML = "";
+            if (data.runners) {
+                const ids = data.runners.slice(0, 6).map(r => r.trim().split(/\s+/)[0]);
+                ids.forEach((id, idx) => {
+                    const h = document.createElement("div");
+                    h.className = "horse";
+                    h.innerHTML = `<span class="number">${id}</span><span class="position">${idx + 1}</span>`;
+                    horseEl.appendChild(h);
+                });
+            }
+
+            document.getElementById("venue-track").textContent =
+                `${data.venue_name || ""} - ${data.track_condition || ""}`;
+            document.getElementById("message1").textContent =
+                data.message1 ? `Margins: ${data.message1}` : "";
+            document.getElementById("message2").textContent =
+                data.message2 ? `Announcement: ${data.message2}` : "";
 
             const resultsEl = document.getElementById("results");
             resultsEl.innerHTML = "";
             if (data.runners) {
-                data.runners.slice(0, 6).forEach((runner, idx) => {
-                    const card = document.createElement("div");
-                    card.className = "result-card";
-                    card.innerHTML = `<strong>${idx + 1}. ${runner}</strong>`;
-                    resultsEl.appendChild(card);
+                data.runners.forEach((runner) => {
+                    const line = document.createElement("div");
+                    line.className = "result-line";
+                    line.textContent = runner;
+                    resultsEl.appendChild(line);
                 });
             }
-
-            document.getElementById("track").textContent =
-                `Track Condition: ${data.track_condition || "Unknown"} | Correct Weight: ${data.correct_weight || "No"}`;
         };
     </script>
 </body>


### PR DESCRIPTION
## Summary
- redesign scoreboard display to show horse IDs and positions
- center venue and track information
- format messages and runner list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6842ec2ec238832b8dfdadccf169604e