### PR TITLE
Show latest result on scoreboard

### DIFF
--- a/scoreboard.py
+++ b/scoreboard.py
@@ -9,6 +9,7 @@ from starlette.websockets import WebSocketState
 import secrets
 import os
 import json
+from datetime import datetime
 
 from database import engine
 from models import Club
@@ -57,7 +58,22 @@ def scoreboard_view(request: Request):
     result = {}
     if os.path.exists(filename):
         with open(filename, "r") as f:
-            result = json.load(f)
+            all_results = json.load(f)
+
+        if isinstance(all_results, dict) and all_results:
+            latest_result = None
+            latest_ts = None
+            for r in all_results.values():
+                ts_str = r.get("timestamp")
+                try:
+                    ts = datetime.fromisoformat(ts_str)
+                except Exception:
+                    ts = None
+                if latest_ts is None or (ts and ts > latest_ts):
+                    latest_ts = ts
+                    latest_result = r
+            if latest_result:
+                result = latest_result
 
     return templates.TemplateResponse("scoreboard_display.html", {"request": request, "club_id": club_id, "result": result})
 

--- a/templates/scoreboard_display.html
+++ b/templates/scoreboard_display.html
@@ -123,12 +123,8 @@
             throw new Error("Missing club_id in URL");
         }
 
-        const ws = new WebSocket(`wss://${location.host}/scoreboard/ws/${clubId}`);
-
-        ws.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-
-            // Top 6 horse IDs with positions
+        /** Update the scoreboard display with the given data */
+        function updateScoreboard(data) {
             const topSix = document.getElementById("topSix");
             topSix.innerHTML = "";
             if (data.runners) {
@@ -140,27 +136,22 @@
                     topSix.appendChild(div);
                 });
 
-                // Display winner's time
                 const winner = data.runners[0];
                 const parts = winner.split(" ");
                 const time = parts.find(p => p.match(/\d+:\d+\.\d+/));
                 document.getElementById("winnerTime").textContent = time ? `Time: ${time}` : "";
             }
 
-            // Correct weight display
             const correctWeightEl = document.getElementById("correctWeight");
             correctWeightEl.textContent = (data.correct_weight?.toLowerCase() === "yes") ? "Correct Weight" : "";
 
-            // Venue name and track condition
             const venue = data.venue_name || "Venue Name";
             const condition = data.track_condition || "Unknown";
             document.getElementById("venueInfo").textContent = `${venue} - ${condition}`;
 
-            // Messages
             document.getElementById("message1").textContent = `Margins: ${data.message1 || ""}`;
             document.getElementById("message2").textContent = `Announcement: ${data.message2 || ""}`;
 
-            // Full runner list without times
             const resultsEl = document.getElementById("results");
             resultsEl.innerHTML = "";
             if (data.runners) {
@@ -172,7 +163,20 @@
                     resultsEl.appendChild(card);
                 });
             }
+        }
+
+        const ws = new WebSocket(`wss://${location.host}/scoreboard/ws/${clubId}`);
+
+        ws.onmessage = (event) => {
+            const data = JSON.parse(event.data);
+            updateScoreboard(data);
         };
+
+        // Render any existing result passed from the server on page load
+        const initialData = {{ result | tojson | safe }};
+        if (Object.keys(initialData).length > 0) {
+            updateScoreboard(initialData);
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load previously submitted race results when scoreboard view loads
- refactor scoreboard JS to reuse the update logic
- pick the most recent result by timestamp when loading scoreboard

## Testing
- `python -m py_compile "LSD Connect/LSD Connect.py" database.py models.py routes.py scoreboard.py server.py`


------
https://chatgpt.com/codex/tasks/task_e_684309d3f320832bba5c1fde7eef056f